### PR TITLE
Feat/pressure at sea level

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://github.com/MarcoAndreaBuchmann/bme280pi/workflows/Tests/badge.svg)](https://github.com/MarcoAndreaBuchmann/bme280pi/actions?query=workflow%3ATests)
-[![Coverage](http://fermion.ch/bme280pi_badges/coverage.svg)](https://github.com/MarcoAndreaBuchmann/bme280pi/actions?query=workflow%3ACoverage)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/74442c7128065652d6da/test_coverage)](https://codeclimate.com/github/MarcoAndreaBuchmann/bme280pi/test_coverage)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/fb51e4dac5ee4e4bbf55c6615aae3597)](https://app.codacy.com/manual/MarcoAndreaBuchmann/bme280pi/dashboard)
 [![Maintainability](https://api.codeclimate.com/v1/badges/74442c7128065652d6da/maintainability)](https://codeclimate.com/github/MarcoAndreaBuchmann/bme280pi/maintainability)
 [![pypi](https://img.shields.io/pypi/v/bme280pi.svg)](https://pypi.org/project/bme280pi/)

--- a/test/physics.py
+++ b/test/physics.py
@@ -1,10 +1,12 @@
 from unittest import TestCase
 
 from bme280pi.physics import (validate_pressure, validate_temperature,
+                              validate_height_above_sea_level,
                               validate_humidity, pressure_function,
                               calculate_abs_humidity, convert_pressure,
                               convert_temperature,
-                              round_to_n_significant_digits)
+                              round_to_n_significant_digits,
+                              pressure_at_sea_level)
 
 
 class TestValidation(TestCase):
@@ -31,6 +33,14 @@ class TestValidation(TestCase):
             validate_humidity(-1)
         with self.assertRaises(ValueError):
             validate_humidity(123)
+
+    def test_height_above_sea_level(self):
+        with self.assertRaises(TypeError):
+            validate_height_above_sea_level("string_input")
+        with self.assertRaises(ValueError):
+            validate_height_above_sea_level(-1)
+        with self.assertRaises(ValueError):
+            validate_height_above_sea_level(12345)
 
 
 class TestPressureFunction(TestCase):
@@ -213,3 +223,37 @@ class TestRoundToNSignificantDigits(TestCase):
             round_to_n_significant_digits(2, -1)
         with self.assertRaises(TypeError):
             round_to_n_significant_digits(2, 1.234)
+
+
+class TestPressureAtSeaLevel(TestCase):
+    def test(self):
+        p = pressure_at_sea_level(pressure=972,
+                                  temperature=25,
+                                  height_above_sea_level=440)
+        self.assertLess(abs(p - 1022.03), 0.01)
+
+    def test_exceptions(self):
+        with self.assertRaises(TypeError):
+            pressure_at_sea_level(pressure="hello",
+                                  temperature=25,
+                                  height_above_sea_level=440)
+        with self.assertRaises(TypeError):
+            pressure_at_sea_level(pressure=972,
+                                  temperature="string",
+                                  height_above_sea_level=440)
+        with self.assertRaises(TypeError):
+            pressure_at_sea_level(pressure=972,
+                                  temperature=25,
+                                  height_above_sea_level="string")
+        with self.assertRaises(ValueError):
+            pressure_at_sea_level(pressure=1234,
+                                  temperature=25,
+                                  height_above_sea_level=440)
+        with self.assertRaises(ValueError):
+            pressure_at_sea_level(pressure=972,
+                                  temperature=123,
+                                  height_above_sea_level=440)
+        with self.assertRaises(ValueError):
+            pressure_at_sea_level(pressure=972,
+                                  temperature=25,
+                                  height_above_sea_level=11111)

--- a/test/readout.py
+++ b/test/readout.py
@@ -212,14 +212,14 @@ class TestReadSensor(TestCase):
     def test_bad_inputs(self):
         fake_data_bus = FakeDataBus(0)
         with self.assertRaises(TypeError):
-            _ = read_sensor(bus=fake_data_bus,
-                            address="fake_address",
-                            oversampling="some_string")
+            read_sensor(bus=fake_data_bus,
+                        address="fake_address",
+                        oversampling="some_string")
         with self.assertRaises(TypeError):
-            _ = read_sensor(bus=fake_data_bus,
-                            address="fake_address",
-                            oversampling=2)
+            read_sensor(bus=fake_data_bus,
+                        address="fake_address",
+                        oversampling=2)
         with self.assertRaises(KeyError):
-            _ = read_sensor(bus=fake_data_bus,
-                            address="fake_address",
-                            oversampling={'something': 2})
+            read_sensor(bus=fake_data_bus,
+                        address="fake_address",
+                        oversampling={'something': 2})

--- a/test/sensor.py
+++ b/test/sensor.py
@@ -117,6 +117,20 @@ class TestSensor(TestCase):
         self.assertLess(abs(pressure - 969.1056565652227), 1e-4)
 
     @mock.patch("bme280pi.Sensor._initialize_bus", initialize_fake_bus)
+    def test_get_pressure_above_sea_level(self):
+        sensor = Sensor()
+        pressure = sensor.get_pressure(height_above_sea_level=440,
+                                       as_pressure_at_sea_level=True)
+        self.assertLess(abs(pressure - 1019.0420210), 1e-4)
+
+    @mock.patch("bme280pi.Sensor._initialize_bus", initialize_fake_bus)
+    def test_get_pressure_without_height_above_sea_level(self):
+        sensor = Sensor()
+        with self.assertRaises(ValueError):
+            sensor.get_pressure(height_above_sea_level=None,
+                                as_pressure_at_sea_level=True)
+
+    @mock.patch("bme280pi.Sensor._initialize_bus", initialize_fake_bus)
     def test_get_humidity(self):
         sensor = Sensor()
         humidity = sensor.get_humidity()
@@ -129,7 +143,7 @@ class TestSensor(TestCase):
     def test_unconfigured_i2c(self):
         with mock.patch('smbus.SMBus', FileNotFoundSMBus):
             with self.assertRaises(I2CException):
-                _ = Sensor()
+                Sensor()
 
 
 class TestPrintSensor(TestCase):


### PR DESCRIPTION
Adds the option to indicate pressure at sea level (which is a commonly used meteorological quantity, QFF instead of QFE)

Source: 

https://keisan.casio.com/keisan/image/Convertpressure.pdf