### PR TITLE
Add address as optional argument to Sensor class

### DIFF
--- a/bme280pi/sensor.py
+++ b/bme280pi/sensor.py
@@ -54,15 +54,18 @@ class Sensor:
     >>> sensor.get_pressure(unit='hPa')
     >>> sensor.get_pressure(unit='mmHg')
     """
-    def __init__(self):
+    def __init__(self, address=0x76):
         """Initialize the sensor class.
 
         Carries out the following steps to initialize the class:
         - detect the Raspberry Pi version
         - initialize the bus
         - store information about the sensor in the class
+
+        Args:
+            address (int): the address of the sensor. default: 0x76
         """
-        self.device_id = 0x76
+        self.address = address
         self.bus = self._initialize_bus()
 
         self.chip_id, self.chip_version = self._get_info_about_sensor()
@@ -150,7 +153,7 @@ class Sensor:
             dict: dictionary with current temperature, humidity, and pressure
         """
         return read_sensor(bus=self.bus,
-                           address=self.device_id)
+                           address=self.address)
 
     def print_data(self, temp_unit='C', relative_humidity=True,
                    pressure_unit='hPa', n_significant_digits=4):
@@ -234,7 +237,7 @@ class Sensor:
             tuple: chip ID and version as one string each
         """
         reg_id = 0xD0
-        chip_id, chip_version = self.bus.read_i2c_block_data(self.device_id,
+        chip_id, chip_version = self.bus.read_i2c_block_data(self.address,
                                                              reg_id,
                                                              2)
         return chip_id, chip_version

--- a/setup.py
+++ b/setup.py
@@ -21,11 +21,11 @@ if sys.version_info.major < 3 or sys.version_info.minor < 5:
     sys.exit(1)
 
 github_url = "https://github.com/MarcoAndreaBuchmann/bme280pi/"
-download_url = github_url + "archive/v1.0.2.tar.gz"
+download_url = github_url + "archive/v1.0.tar.gz"
 
 
 setup(name='bme280pi',
-      version='1.0.2',
+      version='1.1.0',
       license='MIT',
       description="bme280pi: the BME280 Sensor Reader for Raspberry Pi",
       long_description=README,


### PR DESCRIPTION
This merge request adds the optional `address` argument to the `Sensor` class. This allows the user to use the class with other addresses than the default one, or even use two sensors simultaneously.