### PR TITLE
Update setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ package yourself:
 ```bash
 git clone https://github.com/MarcoAndreaBuchmann/bme280pi.git
 cd bme280pi
-python setup.py install
+pip install .
 ```
 
 ## How to Use bme280pi In Your Script


### PR DESCRIPTION
This PR updates the instructions on how to get started with the package in the README file. The old `python setup.py install` command is outdated, and is replaced by the newer `pip install .` command.

Relevant issues: https://github.com/MarcoAndreaBuchmann/bme280pi/issues/16