### PR TITLE
Update name of main branch (and fix PyPI workflow issues)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,10 +2,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [master, ]
+    branches: [main, ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [master]
+    branches: [main]
   schedule:
     - cron: '0 19 * * 2'
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,9 +5,9 @@ name: Coverage
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 permissions:
   contents: read

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -2,7 +2,7 @@ name: Publish to PyPI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
 
 permissions:
     contents: read

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Check if version exists on PyPI
       id: check_pypi
       env:
-        PACKAGE_NAME: your-package-name
+        PACKAGE_NAME: bme280pi
       run: |
         VERSION=$(python -c "import toml; print(toml.load('pyproject.toml')['project']['version'])")
         if curl -sf "https://pypi.org/pypi/$PACKAGE_NAME/$VERSION/json" > /dev/null; then

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -22,6 +22,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install build
+        pip install toml
     
     - name: Build package
       run: python -m build

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -5,9 +5,9 @@ name: Tests
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
The main branch is still named `master` - time to change that to `main` (as any other project).

Also, while pushing to PyPI a number of issues were found that are fixed at the same time.