### PR TITLE
Modernize codebase: add typing, migrate to smbus2, improve docs & tests, enable Read the Docs

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,6 +9,9 @@ on:
   schedule:
     - cron: '0 19 * * 2'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze code quality

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: read
+  security-events: read
 
 jobs:
   analyze:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,14 +22,9 @@ jobs:
         # a pull request then we can checkout the head.
         fetch-depth: 2
 
-    # If this run was triggered by a pull request event, then checkout
-    # the head of the pull request instead of the merge commit.
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
-
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       # Override language selection by uncommenting this and choosing your languages
       # with:
       #   languages: go, javascript, csharp, python, cpp, java
@@ -37,7 +32,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -51,4 +46,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,4 +1,4 @@
-name: "CodeQL"
+name: "Code Quality"
 
 on:
   push:
@@ -11,7 +11,7 @@ on:
 
 jobs:
   analyze:
-    name: Analyze
+    name: Analyze code quality
     runs-on: ubuntu-latest
 
     steps:
@@ -22,28 +22,34 @@ jobs:
         # a pull request then we can checkout the head.
         fetch-depth: 2
 
-    # Initializes the CodeQL tools for scanning.
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.13'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install black isort mypy
+
+    - name: Check code formatting with black
+      run: black . --check --diff
+
+    - name: Check import ordering with isort
+      run: isort . --check --diff
+
+    - name: Check static types with mypy
+      run: mypy .
+
+    # --- CodeQL section starts here ---
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4
       # Override language selection by uncommenting this and choosing your languages
       # with:
       #   languages: go, javascript, csharp, python, cpp, java
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
       uses: github/codeql-action/autobuild@v4
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
-
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-
-    #- run: |
-    #   make bootstrap
-    #   make release
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.12
+        python-version: 3.13
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.12'
+        python-version: '3.13'
     
     - name: Install dependencies
       run: |

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.12
+    - name: Set up Python 3.13
       uses: actions/setup-python@v5
       with:
-        python-version: 3.12
+        python-version: 3.13
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.8.0
+    hooks:
+      - id: black
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.15.0
+    hooks:
+      - id: mypy
+        args: [--strict]
+

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,12 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version, and other tools you might need
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.13"
+

--- a/README.md
+++ b/README.md
@@ -1,10 +1,20 @@
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://pre-commit.com/)
 [![Build Status](https://github.com/MarcoAndreaBuchmann/bme280pi/workflows/Tests/badge.svg)](https://github.com/MarcoAndreaBuchmann/bme280pi/actions?query=workflow%3ATests)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/74442c7128065652d6da/test_coverage)](https://codeclimate.com/github/MarcoAndreaBuchmann/bme280pi/test_coverage)
+[![Test Coverage](https://qlty.sh/gh/marcoandreabuchmann/projects/bme280pi/coverage.svg)](https://qlty.sh/gh/marcoandreabuchmann/projects/bme280pi/)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/fb51e4dac5ee4e4bbf55c6615aae3597)](https://app.codacy.com/manual/MarcoAndreaBuchmann/bme280pi/dashboard)
-[![Maintainability](https://api.codeclimate.com/v1/badges/74442c7128065652d6da/maintainability)](https://codeclimate.com/github/MarcoAndreaBuchmann/bme280pi/maintainability)
+[![Maintainability](https://qlty.sh/gh/marcoandreabuchmann/projects/bme280pi/maintainability.svg)](https://qlty.sh/gh/marcoandreabuchmann/projects/bme280pi/)
 [![pypi](https://img.shields.io/pypi/v/bme280pi.svg)](https://pypi.org/project/bme280pi/)
 
 # bme280pi: the BME280 Sensor Reader for Raspberry Pi
+
+## Quickstart
+Try in a Jupyter notebook or directly:
+```python:disable-run
+from bme280pi import Sensor
+sensor = Sensor()
+print(sensor.get_data())
+```
 
 ## How to Install bme280pi
 
@@ -21,7 +31,7 @@ For a walk-through with screenshots see the references below.
 
 ### 2) Install Utilities
 
-1)  Install `python-smbus` and `i2ctools`: `sudo apt-get update && sudo apt-get install -y python-smbus i2c-tools`
+1)  Install `python-smbus2` and `i2ctools`: `sudo apt-get update && sudo apt-get install -y python-smbus2 i2c-tools`
 2)  Then, shut down your Raspberry Pi:`sudo halt` .
 3)  Disconnect your Raspberry Pi power supply.
 4)  You are now ready to connect the BME280 sensor.
@@ -46,6 +56,12 @@ git clone https://github.com/MarcoAndreaBuchmann/bme280pi.git
 cd bme280pi
 pip install .
 ```
+
+## Troubleshooting
+- I2C not working at all? Run `sudo raspi-config nonint get_i2c` to see if the port is enabled (0=enabled, 1=disabled). If the result is `1` (disabled), run `sudo raspi-config nonint do_i2c 0` to enable it and reboot.
+- I2C not detected? Run `i2cdetect -y 1` and ensure address 0x76/0x77.
+- Permission error: Add user to `i2c` group (`sudo usermod -aG i2c $USER`).
+- No data: Check connections; try forced mode in init.
 
 ## How to Use bme280pi In Your Script
 
@@ -121,6 +137,12 @@ plt.title("Relative Humidity (%)")
 
 plt.savefig("Measurements.png")
 ```
+## Advanced: Build Docs
+```bash
+pip install -r docs/requirements.txt
+cd docs && make html
+```
+Hosted at [ReadTheDocs](https://readthedocs.org/projects/bme280pi/)
 
 ## Reporting Issues
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For a walk-through with screenshots see the references below.
 
 ### 2) Install Utilities
 
-1)  Install `python-smbus2` and `i2ctools`: `sudo apt-get update && sudo apt-get install -y python-smbus2 i2c-tools`
+1)  Install `python3-smbus2` and `i2ctools`: `sudo apt-get update && sudo apt-get install -y python3-smbus2 i2c-tools`
 2)  Then, shut down your Raspberry Pi:`sudo halt` .
 3)  Disconnect your Raspberry Pi power supply.
 4)  You are now ready to connect the BME280 sensor.

--- a/bme280pi/physics.py
+++ b/bme280pi/physics.py
@@ -23,9 +23,10 @@ https://keisan.casio.com/keisan/image/Convertpressure.pdf
 """
 
 import math
+from typing import Union
 
 
-def validate_pressure(pressure):
+def validate_pressure(pressure: Union[float, int]) -> None:
     """Validate input pressure.
 
     Checks that pressure satisfies the following constraints:
@@ -47,10 +48,11 @@ def validate_pressure(pressure):
         raise ValueError("Pressure must be between 0 and 1100")
 
 
-def validate_temperature(temperature):
+def validate_temperature(temperature: Union[float, int]) -> None:
     """Validate input temperature.
 
     Checks that temperature satisfies the following constraints:
+
     - needs to be smaller than 100 degrees (humidity calculations
       don't make much sense above this temperature)
     - needs to be larger than -100 (same reason)
@@ -70,7 +72,7 @@ def validate_temperature(temperature):
         raise ValueError("Temperature must be between -100 and +100")
 
 
-def validate_humidity(rel_humidity):
+def validate_humidity(rel_humidity: Union[float, int]) -> None:
     """Validate input humidity.
 
     Checks that humidity satisfies the following constraints:
@@ -91,7 +93,7 @@ def validate_humidity(rel_humidity):
         raise ValueError("Rel. humidity must be between 0 and 100")
 
 
-def validate_height_above_sea_level(height_above_sea_level):
+def validate_height_above_sea_level(height_above_sea_level: Union[float, int]) -> None:
     """Validate height above sea level.
 
     Checks that height above sea level satisfies the following constraints:
@@ -110,11 +112,10 @@ def validate_height_above_sea_level(height_above_sea_level):
         raise TypeError("Height above sea level must be int or float")
 
     if height_above_sea_level <= 0 or height_above_sea_level > 11000:
-        raise ValueError("Height above sea level must be between zero " +
-                         "and 11000")
+        raise ValueError("Height above sea level must be between zero " + "and 11000")
 
 
-def pressure_function(pressure):
+def pressure_function(pressure: Union[float, int]) -> float:
     """Saturation vapor pressure function.
 
     Calculates the relevant factor to convert the saturation vapor pressure
@@ -130,24 +131,28 @@ def pressure_function(pressure):
     return 1.0016 + 3.16 * 1e-6 * pressure - 0.074 / pressure
 
 
-def calculate_abs_humidity(pressure, temperature, rel_humidity):
+def calculate_abs_humidity(
+    pressure: Union[float, int],
+    temperature: Union[float, int],
+    rel_humidity: Union[float, int],
+) -> float:
     """Calculate the absolute humidity.
 
     The absolute humidity is calculated in the following steps:
-    - we first calculate the saturation vapor pressure in pure phase (e_w)
-    - we use the pressure function f(p) to calculate the saturation vapor
-        pressure of moist air (e_w_moist)
-    - We can then calculate the absolute humidity using the formulae below.
 
-    We start with the ideal gas law, PV = m R T,
-        PV = (m/M) R T
-    where R is the universal gas constant (8.314 kg m^2 / s^2 mol K), and
-    transform it to
-        eV = m R_v T
-    where R_v is the specific gas constant for water vapor (461.5 J / kg K).
-    Then,
-        m / V = e / (R_v T)
-    which is the absolute humidity (i.e. mass of water vapor per volume).
+    1. Saturation vapor pressure over water (Magnus formula):
+       .. math:: e_w(T) = 6.112 \cdot \exp\left( \frac{17.62 \cdot T}{T + 243.12} \right)
+
+    2. Enhancement factor :math:`f(p)` accounts for real moist air
+
+    3. Actual vapor pressure:
+       .. math:: e = \frac{\text{rel\_humidity}}{100} \cdot f(p) \cdot e_w(T)
+
+    4. Absolute humidity (ideal gas law for water vapor):
+       .. math:: AH = \frac{e \cdot 100}{R_v \cdot T_K} \cdot 2.16679
+       .. math:: \quad\text{with } R_v = 461.5\,\text{J}\,\text{kg}^{-1}\,\text{K}^{-1}
+
+       The constant 2.16679 converts from hPa·K to g/m³.
 
     Args:
         pressure (int/float): pressure in hPa
@@ -174,11 +179,13 @@ def calculate_abs_humidity(pressure, temperature, rel_humidity):
     return vapor_pressure / (461.5 * (273.15 + temperature))
 
 
-def convert_pressure(pressure, unit='hPa'):
+def convert_pressure(pressure: Union[float, int], unit: str = "hPa") -> float:
     """Pressure in user-specified unit.
 
     Converts pressure from hPa (input) to the desired unit.
+
     Available options are:
+
      - hPa (`unit='hPa'`)
      - Pa (`unit='Pa'`)
      - kPa (`unit='kPa'`)
@@ -194,11 +201,13 @@ def convert_pressure(pressure, unit='hPa'):
     """
     validate_pressure(pressure)
 
-    conversion_factor = {"hPa": 1,
-                         "Pa": 100,
-                         "kPa": 0.1,
-                         "atm": 9.8692316931427E-4,
-                         "mmHg": 0.750062}
+    conversion_factor = {
+        "hPa": 1,
+        "Pa": 100,
+        "kPa": 0.1,
+        "atm": 9.8692316931427e-4,
+        "mmHg": 0.750062,
+    }
 
     if unit in conversion_factor:
         return conversion_factor[unit] * pressure
@@ -206,7 +215,9 @@ def convert_pressure(pressure, unit='hPa'):
     raise Exception("Unknown pressure unit: " + unit)
 
 
-def convert_temperature(temperature, unit='C'):
+def convert_temperature(
+    temperature: Union[float, int], unit: str = "C"
+) -> Union[float, int]:
     """Temperature in user-specified unit.
 
     Converts temperature from Celsius (input) to the desired unit.
@@ -224,19 +235,23 @@ def convert_temperature(temperature, unit='C'):
     """
     validate_temperature(temperature)
 
-    if unit == 'C':
+    if unit == "C":
         return temperature
 
-    if unit == 'F':
-        return temperature * (9. / 5) + 32.
+    if unit == "F":
+        return temperature * (9.0 / 5) + 32.0
 
-    if unit == 'K':
+    if unit == "K":
         return temperature + 273.15
 
     raise Exception("Unknown temperature unit: " + unit)
 
 
-def pressure_at_sea_level(pressure, temperature, height_above_sea_level):
+def pressure_at_sea_level(
+    pressure: Union[float, int],
+    temperature: Union[float, int],
+    height_above_sea_level: Union[float, int],
+) -> float:
     r"""Convert pressure to pressure at sea level.
 
     Uses a simple formula to convert the observed pressure to the equivalent
@@ -272,17 +287,17 @@ def pressure_at_sea_level(pressure, temperature, height_above_sea_level):
     gamma = -0.0065
     gravitational_acc = 9.80665
     r_d = 287
-    temp = convert_temperature(temperature, unit='K')
+    temp = convert_temperature(temperature, unit="K")
 
-    exponent = - gravitational_acc / (r_d * gamma)
+    exponent = -gravitational_acc / (r_d * gamma)
     nominator = gamma * height_above_sea_level
-    denominator = (temp - gamma * height_above_sea_level)
+    denominator = temp - gamma * height_above_sea_level
     base = 1 + nominator / denominator
 
-    return pressure / pow(base, exponent)
+    return float(pressure / pow(base, exponent))
 
 
-def round_to_n_significant_digits(value, n_digits):
+def round_to_n_significant_digits(value: Union[float, int], n_digits: int) -> float:
     """Round to n significant digits.
 
     Rounds a number to n significant digits, e.g. for 1234 the result

--- a/bme280pi/raspberry_pi_version.py
+++ b/bme280pi/raspberry_pi_version.py
@@ -3,10 +3,11 @@
 Contains the detect_raspberry_pi_version function, which
 detects the version of the Raspberry Pi used.
 """
+
 import warnings
 
 
-def get_list_of_revisions():
+def get_list_of_revisions() -> dict[str, str]:
     """List of known Raspberry Pi Revisions.
 
     Provides a list of known Raspberry Pi CPU IDs and the corresponding
@@ -17,34 +18,36 @@ def get_list_of_revisions():
     Returns:
         dict: dictionary of Raspberry Pi Revisions
     """
-    known_revisions = {'0002': 'Model B R1',
-                       '0003': 'Model B R1',
-                       '0004': 'Model B R2',
-                       '0005': 'Model B R2',
-                       '0006': 'Model B R2',
-                       '0007': 'Model A',
-                       '0008': 'Model A',
-                       '0009': 'Model A',
-                       '000d': 'Model B R2',
-                       '000e': 'Model B R2',
-                       '000f': 'Model B R2',
-                       '0010': 'Model B+',
-                       '0011': 'Compute Module',
-                       '0012': 'Model A+',
-                       'a01041': 'Pi 2 Model B',
-                       'a21041': 'Pi 2 Model B',
-                       '900092': 'Pi Zero',
-                       '900093': 'Pi Zero',
-                       'a02082': 'Pi 3 Model B',
-                       'a22082': 'Pi 3 Model B',
-                       '9000c1': 'Pi Zero W',
-                       'c03111': 'Pi 4 Model B',
-                       'abcdef': 'TestModel',
-                       '0000': 'Unknown'}
+    known_revisions = {
+        "0002": "Model B R1",
+        "0003": "Model B R1",
+        "0004": "Model B R2",
+        "0005": "Model B R2",
+        "0006": "Model B R2",
+        "0007": "Model A",
+        "0008": "Model A",
+        "0009": "Model A",
+        "000d": "Model B R2",
+        "000e": "Model B R2",
+        "000f": "Model B R2",
+        "0010": "Model B+",
+        "0011": "Compute Module",
+        "0012": "Model A+",
+        "a01041": "Pi 2 Model B",
+        "a21041": "Pi 2 Model B",
+        "900092": "Pi Zero",
+        "900093": "Pi Zero",
+        "a02082": "Pi 3 Model B",
+        "a22082": "Pi 3 Model B",
+        "9000c1": "Pi Zero W",
+        "c03111": "Pi 4 Model B",
+        "abcdef": "TestModel",
+        "0000": "Unknown",
+    }
     return known_revisions
 
 
-def detect_raspberry_pi_version():
+def detect_raspberry_pi_version() -> str:
     """Detect the Raspberry Pi Version.
 
     Detects the Raspberry Pi version based on CPU information.

--- a/bme280pi/sensor.py
+++ b/bme280pi/sensor.py
@@ -22,9 +22,13 @@ except ImportError:  # pragma: no cover
     SMBus = None  # type: ignore[misc]
 
 
-from bme280pi.physics import (calculate_abs_humidity, convert_pressure,
-                              convert_temperature, pressure_at_sea_level,
-                              round_to_n_significant_digits)
+from bme280pi.physics import (
+    calculate_abs_humidity,
+    convert_pressure,
+    convert_temperature,
+    pressure_at_sea_level,
+    round_to_n_significant_digits,
+)
 from bme280pi.raspberry_pi_version import detect_raspberry_pi_version
 from bme280pi.readout import read_sensor
 

--- a/bme280pi/sensor.py
+++ b/bme280pi/sensor.py
@@ -10,17 +10,21 @@ For more information about how to use the `Sensor` class, have a look at the
 documentation of the `Sensor` class itself.
 """
 
+from __future__ import annotations
+
 from typing import Any
 
-from smbus2 import SMBus
+# Optional import of smbus2 – only available on real Raspberry Pi hardware
+# mypy: ignore-errors
+try:
+    from smbus2 import SMBus  # noqa: F401
+except ImportError:  # pragma: no cover
+    SMBus = None  # type: ignore[misc]
 
-from bme280pi.physics import (
-    calculate_abs_humidity,
-    convert_pressure,
-    convert_temperature,
-    pressure_at_sea_level,
-    round_to_n_significant_digits,
-)
+
+from bme280pi.physics import (calculate_abs_humidity, convert_pressure,
+                              convert_temperature, pressure_at_sea_level,
+                              round_to_n_significant_digits)
 from bme280pi.raspberry_pi_version import detect_raspberry_pi_version
 from bme280pi.readout import read_sensor
 
@@ -125,7 +129,7 @@ class Sensor:
     def get_pressure(
         self,
         unit: str = "hPa",
-        height_above_sea_level: bool | None = None,
+        height_above_sea_level: int | float | None = None,
         as_pressure_at_sea_level: bool = False,
     ) -> float:
         """Get a pressure reading.

--- a/bme280pi/sensor.py
+++ b/bme280pi/sensor.py
@@ -17,9 +17,9 @@ from typing import Any
 # Optional import of smbus2 – only available on real Raspberry Pi hardware
 # mypy: ignore-errors
 try:
-    from smbus2 import SMBus  # noqa: F401
+    import smbus2  # noqa: F401
 except ImportError:  # pragma: no cover
-    SMBus = None  # type: ignore[misc]
+    smbus2 = None  # type: ignore[misc]
 
 
 from bme280pi.physics import (
@@ -248,7 +248,7 @@ class Sensor:
             argument = 0
 
         try:
-            bus = SMBus(argument)
+            bus = smbus2.SMBus(argument)
         except FileNotFoundError:
             raise I2CException(
                 "SMBus raised a FileNotFoundError; this is "

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,21 @@
+# Minimal makefile for Sphinx documentation (modern layout)
+#
+
+# You can set these variables from the command line.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+clean:
+	@$(SPHINXBUILD) -M clean "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,4 @@
+Sphinx>=7.2,<8
+sphinx-rtd-theme>=2.0,<3
+sphinx-autodoc-typehints>=1.25,<2
+sphinx-copybutton>=0.5,<1

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,0 +1,31 @@
+API Reference
+=============
+
+Main Module
+-----------
+.. automodule:: bme280pi
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Sensor Class
+------------
+.. autoclass:: bme280pi.sensor.Sensor
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Physics Helpers
+---------------
+.. automodule:: bme280pi.physics
+   :members:
+
+Raspberry Pi Version Detection
+------------------------------
+.. automodule:: bme280pi.raspberry_pi_version
+   :members:
+
+Readout Logic
+-------------
+.. automodule:: bme280pi.readout
+   :members:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -71,7 +71,7 @@ templates_path = ["_templates"]
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = []
+exclude_patterns: list[str] = []
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,100 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+# -- Project information -----------------------------------------------------
+project = "bme280pi"
+author = "MarcoAndreaBuchmann"
+master_doc = "index"
+
+import tomllib  # Python 3.11+ (or use 'tomli' on older versions)
+
+with open(os.path.abspath("../../pyproject.toml"), "rb") as f:
+    data = tomllib.load(f)
+release = data["project"]["version"]
+
+version = release
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    "nbsphinx",
+    "IPython.sphinxext.ipython_console_highlighting",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autodoc.typehints",
+    "sphinx.ext.autosectionlabel",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.mathjax",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.viewcode",
+    "sphinxcontrib.jquery",
+    "sphinx_autodoc_typehints",
+    "sphinx_copybutton",
+]
+
+# Nice typehints style
+autodoc_typehints = "description"
+autodoc_typehints_description_target = "all"
+
+# Force MathJax 3 from CDN (this works 100% of the time)
+html_js_files = [
+    "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js",
+]
+
+# Best MathJax 3 config (modern, fast, beautiful)
+mathjax3_config = {
+    "tex": {"inlineMath": [["$", "$"], ["\\(", "\\)"]]},
+    "svg": {"fontCache": "global"},
+}
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ["_templates"]
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = "sphinx_rtd_theme"
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named 'default.css' will overwrite the builtin 'default.css'.
+html_static_path = ["_static"]
+
+html_title = "hftbacktest"
+html_extra_path = ["_html"]
+
+add_module_names = False
+autosummary_generate = True
+autodoc_typehints = "description"
+keep_warnings = False
+
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3.10/", None),
+    "numpy": ("https://numpy.org/doc/stable/", None),
+}

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,15 @@
+Welcome to bme280pi's documentation!
+====================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   api
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,3 +45,15 @@ packages = { find = {} }
 
 [tool.setuptools.package-data]
 "bme280pi" = ["*.py"]
+
+[tool.black]
+line-length = 88
+target-version = ['py311']
+
+[tool.isort]
+profile = "black"
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
+line_length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "smbus",
+    "smbus2",
 ]
 
 [project.optional-dependencies]
@@ -42,3 +42,6 @@ Homepage = "https://github.com/MarcoAndreaBuchmann/bme280pi"
 
 [tool.setuptools]
 packages = { find = {} }
+
+[tool.setuptools.package-data]
+"bme280pi" = ["*.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bme280pi"
-version = "1.2.0"
+version = "1.2.1"
 description = "bme280pi: the BME280 Sensor Reader for Raspberry Pi"
 readme = { file = "README.md", content-type = "text/markdown" }
 license = { text = "MIT" }

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -1,42 +1,41 @@
 from unittest import TestCase
 
-from bme280pi.physics import (validate_pressure, validate_temperature,
+from bme280pi.physics import (calculate_abs_humidity, convert_pressure,
+                              convert_temperature, pressure_at_sea_level,
+                              pressure_function, round_to_n_significant_digits,
                               validate_height_above_sea_level,
-                              validate_humidity, pressure_function,
-                              calculate_abs_humidity, convert_pressure,
-                              convert_temperature,
-                              round_to_n_significant_digits,
-                              pressure_at_sea_level)
+                              validate_humidity, validate_pressure,
+                              validate_temperature)
 
 
 class TestValidation(TestCase):
-    def test_validate_pressure(self):
+    def test_validate_pressure(self) -> None:
         with self.assertRaises(TypeError):
-            validate_pressure("string_input")
+            validate_pressure("string_input")  # type: ignore[arg-type]
         with self.assertRaises(ValueError):
             validate_pressure(-1)
         with self.assertRaises(ValueError):
             validate_pressure(1200)
 
-    def test_validate_temperature(self):
+    def test_validate_temperature(self) -> None:
         with self.assertRaises(TypeError):
-            validate_temperature("string_input")
+            validate_temperature("string_input")  # type: ignore[arg-type]
         with self.assertRaises(ValueError):
             validate_temperature(-111)
         with self.assertRaises(ValueError):
             validate_temperature(111)
 
-    def test_validate_humidity(self):
+    def test_validate_humidity(self) -> None:
         with self.assertRaises(TypeError):
-            validate_humidity("string_input")
+            validate_humidity("string_input")  # type: ignore[arg-type]
         with self.assertRaises(ValueError):
             validate_humidity(-1)
         with self.assertRaises(ValueError):
             validate_humidity(123)
 
-    def test_height_above_sea_level(self):
+    def test_height_above_sea_level(self) -> None:
         with self.assertRaises(TypeError):
-            validate_height_above_sea_level("string_input")
+            validate_height_above_sea_level("string_input")  # type: ignore[arg-type]
         with self.assertRaises(ValueError):
             validate_height_above_sea_level(-1)
         with self.assertRaises(ValueError):
@@ -44,216 +43,217 @@ class TestValidation(TestCase):
 
 
 class TestPressureFunction(TestCase):
-    def test(self):
+    def test(self) -> None:
         test_values = [100, 800, 850, 900, 950, 1000, 1050, 1100]
-        correct_values = [1.001176,
-                          1.0040355,
-                          1.0041989411764707,
-                          1.0043617777777778,
-                          1.004524105263158,
-                          1.0046860000000002,
-                          1.0048475238095238,
-                          1.0050087272727273]
+        correct_values = [
+            1.001176,
+            1.0040355,
+            1.0041989411764707,
+            1.0043617777777778,
+            1.004524105263158,
+            1.0046860000000002,
+            1.0048475238095238,
+            1.0050087272727273,
+        ]
 
         for i_test, test_value in enumerate(test_values):
             test_result = pressure_function(test_value)
             correct_result = correct_values[i_test]
             self.assertLess(abs(test_result - correct_result), 1e-6)
 
-    def test_exceptions(self):
+    def test_exceptions(self) -> None:
         with self.assertRaises(ValueError):
             pressure_function(0)
         with self.assertRaises(ValueError):
             pressure_function(1111)
         with self.assertRaises(TypeError):
-            pressure_function('a')
+            pressure_function("a")  # type: ignore[arg-type]
 
 
 class TestCalculateAbsHumidity(TestCase):
-    def test(self):
+    def test(self) -> None:
         test_pressure = [100, 800, 850, 900, 950, 1000, 1050, 1100]
         test_temp = [-10, 0, 10, 15, 20, 25, 40, 60]
         test_rel = [80, 10, 20, 90, 40, 50, 43.25, 12.34]
 
-        correct_values = [0.0018930155819513275,
-                          0.00048681001461818693,
-                          0.0018843546921809028,
-                          0.011566932891098143,
-                          0.006927846890531939,
-                          0.011536889704637605,
-                          0.022155411985739303,
-                          0.01612715205125449]
+        correct_values = [
+            0.0018930155819513275,
+            0.00048681001461818693,
+            0.0018843546921809028,
+            0.011566932891098143,
+            0.006927846890531939,
+            0.011536889704637605,
+            0.022155411985739303,
+            0.01612715205125449,
+        ]
 
         for i_test, correct_value in enumerate(correct_values):
-            result = calculate_abs_humidity(pressure=test_pressure[i_test],
-                                            temperature=test_temp[i_test],
-                                            rel_humidity=test_rel[i_test])
+            result = calculate_abs_humidity(
+                pressure=test_pressure[i_test],
+                temperature=test_temp[i_test],
+                rel_humidity=test_rel[i_test],
+            )
             self.assertLess(abs(result - correct_value), 1e-6)
 
-    def test_valid_range(self):
+    def test_valid_range(self) -> None:
         with self.assertRaises(ValueError):
             # pressure too low
-            calculate_abs_humidity(pressure=0,
-                                   temperature=25,
-                                   rel_humidity=50)
+            calculate_abs_humidity(pressure=0, temperature=25, rel_humidity=50)
         with self.assertRaises(ValueError):
             # pressure too high
-            calculate_abs_humidity(pressure=1111,
-                                   temperature=25,
-                                   rel_humidity=50)
+            calculate_abs_humidity(pressure=1111, temperature=25, rel_humidity=50)
         with self.assertRaises(ValueError):
             # rel humidity too low
-            calculate_abs_humidity(pressure=975,
-                                   temperature=25,
-                                   rel_humidity=-1)
+            calculate_abs_humidity(pressure=975, temperature=25, rel_humidity=-1)
         with self.assertRaises(ValueError):
             # rel humidity too high
-            calculate_abs_humidity(pressure=975,
-                                   temperature=25,
-                                   rel_humidity=110)
+            calculate_abs_humidity(pressure=975, temperature=25, rel_humidity=110)
         with self.assertRaises(ValueError):
             # temp too low
-            calculate_abs_humidity(pressure=975,
-                                   temperature=-101,
-                                   rel_humidity=50)
+            calculate_abs_humidity(pressure=975, temperature=-101, rel_humidity=50)
         with self.assertRaises(ValueError):
             # temp too high
-            calculate_abs_humidity(pressure=975,
-                                   temperature=101,
-                                   rel_humidity=50)
+            calculate_abs_humidity(pressure=975, temperature=101, rel_humidity=50)
 
-    def test_bad_arguments(self):
+    def test_bad_arguments(self) -> None:
         with self.assertRaises(TypeError):
-            calculate_abs_humidity(pressure='a',
-                                   temperature=25,
-                                   rel_humidity=110)
+            calculate_abs_humidity(pressure="a", temperature=25, rel_humidity=110)  # type: ignore[arg-type]
         with self.assertRaises(TypeError):
-            calculate_abs_humidity(pressure=975,
-                                   temperature='a',
-                                   rel_humidity=110)
+            calculate_abs_humidity(pressure=975, temperature="a", rel_humidity=110)  # type: ignore[arg-type]
         with self.assertRaises(TypeError):
-            calculate_abs_humidity(pressure=975,
-                                   temperature=25,
-                                   rel_humidity='a')
+            calculate_abs_humidity(pressure=975, temperature=25, rel_humidity="a")  # type: ignore[arg-type]
 
 
 class TestConvertPressure(TestCase):
-    def test(self):
+    def test(self) -> None:
         test_values = [100, 500, 850, 900, 950, 1000, 1050, 1099]
 
-        correct_values = {'hPa': test_values,
-                          'Pa': [100 * p for p in test_values],
-                          'kPa': [0.1 * p for p in test_values],
-                          'atm': [9.8692316931427E-4 * p for p in test_values],
-                          'mmHg': [0.750062 * p for p in test_values]}
+        correct_values = {
+            "hPa": test_values,
+            "Pa": [100 * p for p in test_values],
+            "kPa": [0.1 * p for p in test_values],
+            "atm": [9.8692316931427e-4 * p for p in test_values],
+            "mmHg": [0.750062 * p for p in test_values],
+        }
 
         for unit in correct_values:
-            for i in range(len(correct_values[unit])):
-                self.assertLess(abs(correct_values[unit][i] -
-                                    convert_pressure(test_values[i],
-                                                     unit=unit)),
-                                1e-6)
+            for i in range(len(correct_values[unit])):  # type: ignore[arg-type]
+                self.assertLess(
+                    abs(
+                        correct_values[unit][i]  # type: ignore[index]
+                        - convert_pressure(test_values[i], unit=unit)
+                    ),
+                    1e-6,
+                )
 
-    def test_exceptions(self):
+    def test_exceptions(self) -> None:
         with self.assertRaises(ValueError):
             convert_pressure(-123)
         with self.assertRaises(ValueError):
             convert_pressure(1234)
 
         with self.assertRaises(TypeError):
-            convert_pressure('a')
+            convert_pressure("a")  # type: ignore[arg-type]
         with self.assertRaises(Exception):
-            convert_pressure(123, 'UnknownUnit')
+            convert_pressure(123, "UnknownUnit")
 
 
 class TestConvertTemperature(TestCase):
-    def test(self):
+    def test(self) -> None:
         test_values = [-50, -40, 30, 20, 10, 0, 12.34, 20, 30, 40, 50, 99]
 
-        correct_values = {'C': test_values,
-                          'F': [32 + (9. / 5) * t for t in test_values],
-                          'K': [273.15 + t for t in test_values]}
+        correct_values = {
+            "C": test_values,
+            "F": [32 + (9.0 / 5) * t for t in test_values],
+            "K": [273.15 + t for t in test_values],
+        }
 
         for unit in correct_values:
             for i in range(len(correct_values[unit])):
-                self.assertLess(abs(correct_values[unit][i] -
-                                    convert_temperature(test_values[i],
-                                                        unit=unit)),
-                                1e-6)
+                self.assertLess(
+                    abs(
+                        correct_values[unit][i]
+                        - convert_temperature(test_values[i], unit=unit)
+                    ),
+                    1e-6,
+                )
 
-    def test_exceptions(self):
+    def test_exceptions(self) -> None:
         with self.assertRaises(ValueError):
             convert_temperature(-123)
         with self.assertRaises(ValueError):
             convert_temperature(123)
 
         with self.assertRaises(TypeError):
-            convert_temperature('a')
+            convert_temperature("a")  # type: ignore[arg-type]
         with self.assertRaises(Exception):
-            convert_temperature(23, 'UnknownUnit')
+            convert_temperature(23, "UnknownUnit")
 
 
 class TestRoundToNSignificantDigits(TestCase):
-    def test(self):
+    def test(self) -> None:
         multipliers = [0.001, 0.01, 0.1, 1, 10, 100, 1000]
         test_values = [1.23456789 * m for m in multipliers]
 
-        correct_results = {1: [1 * m for m in multipliers],
-                           2: [1.2 * m for m in multipliers],
-                           3: [1.23 * m for m in multipliers],
-                           4: [1.235 * m for m in multipliers],
-                           5: [1.2346 * m for m in multipliers]}
+        correct_results = {
+            1: [1 * m for m in multipliers],
+            2: [1.2 * m for m in multipliers],
+            3: [1.23 * m for m in multipliers],
+            4: [1.235 * m for m in multipliers],
+            5: [1.2346 * m for m in multipliers],
+        }
 
         for n_digits in correct_results:
             for i, test_value in enumerate(test_values):
-                test_result = round_to_n_significant_digits(test_value,
-                                                            n_digits)
-                self.assertLess(abs(correct_results[n_digits][i] -
-                                    test_result),
-                                1e-6)
+                test_result = round_to_n_significant_digits(test_value, n_digits)
+                self.assertLess(abs(correct_results[n_digits][i] - test_result), 1e-6)
 
-    def test_exceptions(self):
+    def test_exceptions(self) -> None:
         with self.assertRaises(TypeError):
-            round_to_n_significant_digits('a', 2)
+            round_to_n_significant_digits("a", 2)  # type: ignore[arg-type]
         with self.assertRaises(TypeError):
-            round_to_n_significant_digits(2, 'a')
+            round_to_n_significant_digits(2, "a")  # type: ignore[arg-type]
         with self.assertRaises(ValueError):
             round_to_n_significant_digits(2, 0)
         with self.assertRaises(ValueError):
             round_to_n_significant_digits(2, -1)
         with self.assertRaises(TypeError):
-            round_to_n_significant_digits(2, 1.234)
+            round_to_n_significant_digits(2, 1.234)  # type: ignore[arg-type]
 
 
 class TestPressureAtSeaLevel(TestCase):
-    def test(self):
-        p = pressure_at_sea_level(pressure=972,
-                                  temperature=25,
-                                  height_above_sea_level=440)
+    def test(self) -> None:
+        p = pressure_at_sea_level(
+            pressure=972, temperature=25, height_above_sea_level=440
+        )
         self.assertLess(abs(p - 1022.03), 0.01)
 
-    def test_exceptions(self):
+    def test_exceptions(self) -> None:
         with self.assertRaises(TypeError):
-            pressure_at_sea_level(pressure="hello",
-                                  temperature=25,
-                                  height_above_sea_level=440)
+            pressure_at_sea_level(
+                pressure="hello",  # type: ignore[arg-type]
+                temperature=25,
+                height_above_sea_level=440,
+            )
         with self.assertRaises(TypeError):
-            pressure_at_sea_level(pressure=972,
-                                  temperature="string",
-                                  height_above_sea_level=440)
+            pressure_at_sea_level(
+                pressure=972,
+                temperature="string",  # type: ignore[arg-type]
+                height_above_sea_level=440,
+            )
         with self.assertRaises(TypeError):
-            pressure_at_sea_level(pressure=972,
-                                  temperature=25,
-                                  height_above_sea_level="string")
+            pressure_at_sea_level(
+                pressure=972, temperature=25, height_above_sea_level="string"  # type: ignore[arg-type]
+            )
         with self.assertRaises(ValueError):
-            pressure_at_sea_level(pressure=1234,
-                                  temperature=25,
-                                  height_above_sea_level=440)
+            pressure_at_sea_level(
+                pressure=1234, temperature=25, height_above_sea_level=440
+            )
         with self.assertRaises(ValueError):
-            pressure_at_sea_level(pressure=972,
-                                  temperature=123,
-                                  height_above_sea_level=440)
+            pressure_at_sea_level(
+                pressure=972, temperature=123, height_above_sea_level=440
+            )
         with self.assertRaises(ValueError):
-            pressure_at_sea_level(pressure=972,
-                                  temperature=25,
-                                  height_above_sea_level=11111)
+            pressure_at_sea_level(
+                pressure=972, temperature=25, height_above_sea_level=11111
+            )

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -1,11 +1,17 @@
 from unittest import TestCase
 
-from bme280pi.physics import (calculate_abs_humidity, convert_pressure,
-                              convert_temperature, pressure_at_sea_level,
-                              pressure_function, round_to_n_significant_digits,
-                              validate_height_above_sea_level,
-                              validate_humidity, validate_pressure,
-                              validate_temperature)
+from bme280pi.physics import (
+    calculate_abs_humidity,
+    convert_pressure,
+    convert_temperature,
+    pressure_at_sea_level,
+    pressure_function,
+    round_to_n_significant_digits,
+    validate_height_above_sea_level,
+    validate_humidity,
+    validate_pressure,
+    validate_temperature,
+)
 
 
 class TestValidation(TestCase):

--- a/tests/test_raspberry_pi_version.py
+++ b/tests/test_raspberry_pi_version.py
@@ -1,0 +1,29 @@
+from typing import Any
+from unittest import TestCase, mock
+
+from bme280pi.raspberry_pi_version import (detect_raspberry_pi_version,
+                                           get_list_of_revisions)
+
+
+def raise_exception(*args: Any, **kwargs: Any) -> None:
+    raise FileNotFoundError
+
+
+class TestDetectRaspberryPiVersion(TestCase):
+    def test(self) -> None:
+        known_revisions = get_list_of_revisions()
+
+        known_revisions["bad_id"] = "Unknown"
+
+        for revision in known_revisions:
+            mopen = mock.mock_open(read_data="\nRevision:" + revision + "\n")
+            with mock.patch("builtins.open", mopen):
+                self.assertEqual(
+                    detect_raspberry_pi_version(), known_revisions[revision]
+                )
+
+    def test_exception(self) -> None:
+        mopen = raise_exception
+        with mock.patch("builtins.open", mopen):
+            with self.assertWarns(Warning):
+                self.assertEqual(detect_raspberry_pi_version(), "Unknown")

--- a/tests/test_raspberry_pi_version.py
+++ b/tests/test_raspberry_pi_version.py
@@ -1,8 +1,10 @@
 from typing import Any
 from unittest import TestCase, mock
 
-from bme280pi.raspberry_pi_version import (detect_raspberry_pi_version,
-                                           get_list_of_revisions)
+from bme280pi.raspberry_pi_version import (
+    detect_raspberry_pi_version,
+    get_list_of_revisions,
+)
 
 
 def raise_exception(*args: Any, **kwargs: Any) -> None:

--- a/tests/test_readout.py
+++ b/tests/test_readout.py
@@ -1,14 +1,21 @@
 from typing import Any
 from unittest import TestCase
 
-from bme280pi.readout import (extract_raw_values, extract_values,
-                              get_character, get_modified, get_short,
-                              get_unsigned_character, get_unsigned_short,
-                              improve_humidity_measurement,
-                              improve_pressure_measurement,
-                              improve_temperature_measurement,
-                              process_calibration_data, read_raw_sensor,
-                              read_sensor)
+from bme280pi.readout import (
+    extract_raw_values,
+    extract_values,
+    get_character,
+    get_modified,
+    get_short,
+    get_unsigned_character,
+    get_unsigned_short,
+    improve_humidity_measurement,
+    improve_pressure_measurement,
+    improve_temperature_measurement,
+    process_calibration_data,
+    read_raw_sensor,
+    read_sensor,
+)
 from tests.test_sensor import FakeDataBus
 
 

--- a/tests/test_readout.py
+++ b/tests/test_readout.py
@@ -1,14 +1,14 @@
+from typing import Any
 from unittest import TestCase
 
-from bme280pi.readout import (get_short, get_unsigned_short, get_character,
-                              get_unsigned_character, read_raw_sensor,
-                              get_modified, process_calibration_data,
-                              extract_raw_values,
-                              improve_temperature_measurement,
+from bme280pi.readout import (extract_raw_values, extract_values,
+                              get_character, get_modified, get_short,
+                              get_unsigned_character, get_unsigned_short,
+                              improve_humidity_measurement,
                               improve_pressure_measurement,
-                              improve_humidity_measurement, extract_values,
+                              improve_temperature_measurement,
+                              process_calibration_data, read_raw_sensor,
                               read_sensor)
-
 from tests.test_sensor import FakeDataBus
 
 
@@ -18,69 +18,71 @@ class FakeRecordingBus:
     This "bus" class records all commands, which allows tests
     to check that the right sequence is called.
     """
-    def __init__(self):
+
+    def __init__(self) -> None:
         """
         Initialize a fake bus class
         """
-        self.commands = []
+        self.commands: list[list[Any]] = []
 
-    def write_byte_data(self, address, register, value, force=None):
-        self.commands.append(['write_byte_data', address, register,
-                              value, force])
+    def write_byte_data(
+        self, address: int, register: int, value: int, force: bool | None = None
+    ) -> None:
+        self.commands.append(["write_byte_data", address, register, value, force])
 
-    def read_i2c_block_data(self, address, register, length, force=None):
-        self.commands.append(['read_i2c_block_data', address, register,
-                              length, force])
+    def read_i2c_block_data(
+        self, address: int, register: int, length: int, force: bool | None = None
+    ) -> int:
+        self.commands.append(["read_i2c_block_data", address, register, length, force])
         return len(self.commands)
 
 
 class TestGetShort(TestCase):
-    def test(self):
+    def test(self) -> None:
         test_result = get_short(data=[129, 1, 0, 16, 44, 3, 30], index=0)
         self.assertLess(abs(test_result - 385), 1e-6)
 
 
 class TestGetUnsignedshort(TestCase):
-    def test(self):
-        test_result = get_unsigned_short(data=[129, 1, 0, 16, 44, 3, 30],
-                                         index=0)
+    def test(self) -> None:
+        test_result = get_unsigned_short(data=[129, 1, 0, 16, 44, 3, 30], index=0)
         self.assertLess(abs(test_result - 385), 1e-6)
 
 
 class TestGetCharacter(TestCase):
-    def test(self):
+    def test(self) -> None:
         test_result = get_character(data=[129, 1, 0, 16, 44, 3, 30], index=0)
         self.assertLess(abs(test_result + 127), 1e-6)
 
 
 class TestGetUnsignedCharacter(TestCase):
-    def test(self):
-        test_result = get_unsigned_character(data=[129, 1, 0, 16, 44, 3, 30],
-                                             index=0)
+    def test(self) -> None:
+        test_result = get_unsigned_character(data=[129, 1, 0, 16, 44, 3, 30], index=0)
         self.assertLess(abs(test_result - 129), 1e-6)
 
 
 class TestReadRawSensor(TestCase):
-    def test(self):
+    def test(self) -> None:
         bus = FakeRecordingBus()
-        cals, data = read_raw_sensor(bus=bus,
-                                     address="address",
-                                     oversampling={'temperature': 2,
-                                                   'pressure': 2,
-                                                   'humidity': 2},
-                                     reg_data="reg_data")
+        cals, data = read_raw_sensor(
+            bus=bus,
+            address=0xFFFFF,
+            oversampling={"temperature": 2, "pressure": 2, "humidity": 2},
+            reg_data=0xEEEEE,
+        )
         self.assertEqual(cals[0], 3)
         self.assertEqual(cals[1], 4)
         self.assertEqual(cals[2], 5)
         self.assertEqual(data, 6)
 
-        correct_commands = [['write_byte_data', 'address', 242, 2, None],
-                            ['write_byte_data', 'address', 244, 73, None],
-                            ['read_i2c_block_data', 'address', 136, 24, None],
-                            ['read_i2c_block_data', 'address', 161, 1, None],
-                            ['read_i2c_block_data', 'address', 225, 7, None],
-                            ['read_i2c_block_data', 'address', 'reg_data', 8,
-                             None]]
+        correct_commands = [
+            ["write_byte_data", 0xFFFFF, 242, 2, None],
+            ["write_byte_data", 0xFFFFF, 244, 73, None],
+            ["read_i2c_block_data", 0xFFFFF, 136, 24, None],
+            ["read_i2c_block_data", 0xFFFFF, 161, 1, None],
+            ["read_i2c_block_data", 0xFFFFF, 225, 7, None],
+            ["read_i2c_block_data", 0xFFFFF, 0xEEEEE, 8, None],
+        ]
 
         for i, correct_value in enumerate(correct_commands):
             # check type of command
@@ -95,31 +97,54 @@ class TestReadRawSensor(TestCase):
             self.assertEqual(bus.commands[i][4], correct_value[4])
 
 
-def get_reference_calibration_data():
-    return ([96, 110, 203, 104, 50, 0, 29, 145, 59, 215, 208, 11, 232, 38,
-             42, 255, 249, 255, 172, 38, 10, 216, 189, 16],
-            [75],
-            [129, 1, 0, 16, 44, 3, 30])
+def get_reference_calibration_data() -> list[list[int]]:
+    return [
+        [
+            96,
+            110,
+            203,
+            104,
+            50,
+            0,
+            29,
+            145,
+            59,
+            215,
+            208,
+            11,
+            232,
+            38,
+            42,
+            255,
+            249,
+            255,
+            172,
+            38,
+            10,
+            216,
+            189,
+            16,
+        ],
+        [75],
+        [129, 1, 0, 16, 44, 3, 30],
+    ]
 
 
 class TestGetModified(TestCase):
-    def test(self):
+    def test(self) -> None:
         cals = get_reference_calibration_data()
 
         self.assertEqual(get_modified(cals, 3, get_character), 268)
         self.assertEqual(get_modified(cals, 3, get_unsigned_character), 268)
-        self.assertEqual(get_modified(cals, 5, get_unsigned_character,
-                                      shift=True),
-                         50)
+        self.assertEqual(get_modified(cals, 5, get_unsigned_character, shift=True), 50)
 
 
 class TestProcessCalibration(TestCase):
-    def test(self):
+    def test(self) -> None:
         cals = get_reference_calibration_data()
 
         correct_dig_t = [28256, 26827, 50]
-        correct_dig_p = [37149, -10437, 3024, 9960, -214, -7, 9900, -10230,
-                         4285]
+        correct_dig_p = [37149, -10437, 3024, 9960, -214, -7, 9900, -10230, 4285]
         correct_dig_h = [75, 385, 0, 268, 50, 30]
 
         dig_t, dig_p, dig_h = process_calibration_data(cals)
@@ -138,7 +163,7 @@ class TestProcessCalibration(TestCase):
 
 
 class TestExtractRawValues(TestCase):
-    def test(self):
+    def test(self) -> None:
         data = [76, 60, 0, 129, 49, 128, 94, 110]
         raw_pressure, raw_temperature, raw_humidity = extract_raw_values(data)
         self.assertEqual(raw_pressure, 312256)
@@ -147,7 +172,7 @@ class TestExtractRawValues(TestCase):
 
 
 class TestImproveTemperatureMeasurements(TestCase):
-    def test(self):
+    def test(self) -> None:
         temp_raw = 529168
         dig_t = [28256, 26827, 50]
         temperature, t_fine = improve_temperature_measurement(temp_raw, dig_t)
@@ -156,7 +181,7 @@ class TestImproveTemperatureMeasurements(TestCase):
 
 
 class TestImprovePressureMeasurements(TestCase):
-    def test(self):
+    def test(self) -> None:
         # normal case
         raw_pressure = 312272
         dig_p = [37149, -10437, 3024, 9960, -214, -7, 9900, -10230, 4285]
@@ -164,7 +189,7 @@ class TestImprovePressureMeasurements(TestCase):
         pressure = improve_pressure_measurement(raw_pressure, dig_p, t_fine)
         self.assertLess(abs(pressure - 96909.62784910419), 1e-4)
 
-    def test_special_case(self):
+    def test_special_case(self) -> None:
         # special case (var1 = 0)
         raw_pressure = 312272
         dig_p = [0, 6034, -2009, -3141, 8460, 523, -7938, 6421, -4430]
@@ -174,7 +199,7 @@ class TestImprovePressureMeasurements(TestCase):
 
 
 class TestHumidityMeasurements(TestCase):
-    def test(self):
+    def test(self) -> None:
         raw_humidity = 24185
         dig_h = [75, 385, 0, 268, 50, 30]
         t_fine = 126200
@@ -183,7 +208,7 @@ class TestHumidityMeasurements(TestCase):
 
 
 class TestExtractValues(TestCase):
-    def test(self):
+    def test(self) -> None:
         data = [76, 59, 0, 129, 48, 0, 94, 121]
         dig_t = [28256, 26827, 50]
         dig_p = [37149, -10437, 3024, 9960, -214, -7, 9900, -10230, 4285]
@@ -196,30 +221,30 @@ class TestExtractValues(TestCase):
 
 
 class TestReadSensor(TestCase):
-    def test(self):
+    def test(self) -> None:
         fake_data_bus = FakeDataBus(starting_point=0)
-        correct_result = {'temperature': 24.65,
-                          'pressure': 969.1056565652227,
-                          'humidity': 41.07329061361983}
+        correct_result = {
+            "temperature": 24.65,
+            "pressure": 969.1056565652227,
+            "humidity": 41.07329061361983,
+        }
 
-        test_result = read_sensor(bus=fake_data_bus,
-                                  address="fake_address")
+        test_result = read_sensor(bus=fake_data_bus, address=0xFFFFF)
 
         for k in test_result:
-            self.assertLess(abs(test_result[k] - correct_result[k]),
-                            1e-4)
+            self.assertLess(abs(test_result[k] - correct_result[k]), 1e-4)
 
-    def test_bad_inputs(self):
+    def test_bad_inputs(self) -> None:
         fake_data_bus = FakeDataBus(0)
         with self.assertRaises(TypeError):
-            read_sensor(bus=fake_data_bus,
-                        address="fake_address",
-                        oversampling="some_string")
+            read_sensor(
+                bus=fake_data_bus,
+                address=0xFFFFF,
+                oversampling="some_string",  # type: ignore[arg-type]
+            )
         with self.assertRaises(TypeError):
-            read_sensor(bus=fake_data_bus,
-                        address="fake_address",
-                        oversampling=2)
+            read_sensor(bus=fake_data_bus, address=0xFFFF, oversampling=2)  # type: ignore[arg-type]
         with self.assertRaises(KeyError):
-            read_sensor(bus=fake_data_bus,
-                        address="fake_address",
-                        oversampling={'something': 2})
+            read_sensor(
+                bus=fake_data_bus, address=0xFFFF, oversampling={"something": 2}
+            )

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,3 +1,4 @@
+import builtins
 import io
 from typing import Any
 from unittest import TestCase, mock
@@ -154,7 +155,7 @@ class TestSensor(TestCase):
     def test_get_pressure_above_sea_level(self) -> None:
         sensor = Sensor()
         pressure = sensor.get_pressure(
-            height_above_sea_level=440,  # type: ignore[arg-type]
+            height_above_sea_level=440,
             as_pressure_at_sea_level=True,
         )
         self.assertLess(abs(pressure - 1019.0420210), 1e-4)
@@ -178,7 +179,11 @@ class TestSensor(TestCase):
         self.assertLess(abs(humidity - 0.009291279797753835), 1e-4)
 
     def test_unconfigured_i2c(self) -> None:
-        with mock.patch("smbus2.SMBus", FileNotFoundSMBus):
+        fake_open = mock.mock_open(read_data="Revision\t: 0000\n")
+        with (
+            mock.patch("smbus2.SMBus", FileNotFoundSMBus),
+            mock.patch(f"{builtins.__name__}.open", fake_open),
+        ):
             with self.assertRaises(I2CException):
                 Sensor()
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,11 +1,12 @@
 import io
+from typing import Any
 from unittest import TestCase, mock
 
-from bme280pi.sensor import Sensor, I2CException
+from bme280pi.sensor import I2CException, Sensor
 
 
 class FakeSMBus:
-    def __init__(self, value):
+    def __init__(self, value: int) -> None:
         """
         This is a fake bus class (to replace SMBus).
         It records the value it is initialized with, and makes
@@ -15,72 +16,105 @@ class FakeSMBus:
         self.value = value
 
     @staticmethod
-    def read_i2c_block_data(address, register, length, force=None):
+    def read_i2c_block_data(
+        address: int, register: int, length: int, force: bool | None = None
+    ) -> tuple[str, str]:
         return "fake_chip_id", "fake_version"
 
 
 class TestInitializeBus(TestCase):
-    def test(self):
+    def test(self) -> None:
         # this test requires us to override the processor type and smbbus
-        known_revisions = {'0002': 0,
-                           '0003': 0,
-                           '0004': 1,
-                           '0005': 1,
-                           '0006': 1,
-                           '0007': 0,
-                           '0008': 0,
-                           '0009': 0,
-                           '000d': 1,
-                           '000e': 1,
-                           '000f': 1,
-                           '0010': 0,
-                           '0011': 1,
-                           '0012': 0,
-                           'a01041': 1,
-                           'a21041': 1,
-                           '900092': 1,
-                           '900093': 1,
-                           'a02082': 1,
-                           'a22082': 1,
-                           '9000c1': 1,
-                           'c03111': 1,
-                           'abcdef': 1,
-                           '0000': 1}
+        known_revisions = {
+            "0002": 0,
+            "0003": 0,
+            "0004": 1,
+            "0005": 1,
+            "0006": 1,
+            "0007": 0,
+            "0008": 0,
+            "0009": 0,
+            "000d": 1,
+            "000e": 1,
+            "000f": 1,
+            "0010": 0,
+            "0011": 1,
+            "0012": 0,
+            "a01041": 1,
+            "a21041": 1,
+            "900092": 1,
+            "900093": 1,
+            "a02082": 1,
+            "a22082": 1,
+            "9000c1": 1,
+            "c03111": 1,
+            "abcdef": 1,
+            "0000": 1,
+        }
 
         for revision in known_revisions:
             m = mock.mock_open(read_data="\nRevision:" + revision + "\n")
-            with mock.patch('builtins.open', m):
-                with mock.patch('smbus.SMBus', FakeSMBus):
+            with mock.patch("builtins.open", m):
+                with mock.patch("smbus2.SMBus", FakeSMBus):
                     sensor = Sensor()
-                    self.assertEqual(sensor.bus.value,
-                                     known_revisions[revision])
+                    self.assertEqual(sensor.bus.value, known_revisions[revision])
 
 
 class FakeDataBus:
-    def __init__(self, starting_point=-1):
+    def __init__(self, starting_point: int = -1) -> None:
         """
         A further fake bus class (to replace SMBus).
         This version returns data that is a realistic representation
         of actual data
         """
         self.i_read = starting_point
-        self.data = [['fake_chip_id', 'fake_version'],
-                     [96, 110, 203, 104, 50, 0, 29, 145, 59, 215, 208, 11,
-                      232, 38, 42, 255, 249, 255, 172, 38, 10, 216, 189, 16],
-                     [75],
-                     [129, 1, 0, 16, 44, 3, 30],
-                     [76, 60, 128, 129, 49, 128, 94, 120]]
+        self.data = [
+            ["fake_chip_id", "fake_version"],
+            [
+                96,
+                110,
+                203,
+                104,
+                50,
+                0,
+                29,
+                145,
+                59,
+                215,
+                208,
+                11,
+                232,
+                38,
+                42,
+                255,
+                249,
+                255,
+                172,
+                38,
+                10,
+                216,
+                189,
+                16,
+            ],
+            [75],
+            [129, 1, 0, 16, 44, 3, 30],
+            [76, 60, 128, 129, 49, 128, 94, 120],
+        ]
 
-    def write_byte_data(self, address, register, value, force=None):
+    def write_byte_data(
+        self, address: int, register: int, value: int, force: bool | None = None
+    ) -> None:
         pass
 
-    def read_i2c_block_data(self, address, register, length, force=None):
+    def read_i2c_block_data(
+        self, address: int, register: int, length: int, force: bool | None = None
+    ) -> list[int]:
         self.i_read += 1
-        return self.data[self.i_read]
+        return self.data[self.i_read]  # type: ignore[return-value]
 
 
 class FileNotFoundSMBus:
-    def __init__(self, bus_address):
+    def __init__(self, bus_address: int) -> None:
         """
         This fake bus class raises a FileNotFoundError, because that's what
         SMBus can do in case I2C is not configured.
@@ -88,50 +122,53 @@ class FileNotFoundSMBus:
         raise FileNotFoundError("No such file or directory")
 
 
-def initialize_fake_bus(*args, **kwargs):
+def initialize_fake_bus(*args: Any, **kwargs: Any) -> Any:
     return FakeDataBus()
 
 
 class TestSensor(TestCase):
     @mock.patch("bme280pi.Sensor._initialize_bus", initialize_fake_bus)
-    def test_get_data(self):
+    def test_get_data(self) -> None:
         sensor = Sensor()
         self.assertEqual(sensor.chip_id, "fake_chip_id")
         self.assertEqual(sensor.chip_version, "fake_version")
 
         data = sensor.get_data()
-        self.assertLess(abs(data['temperature'] - 24.65), 1e-4)
-        self.assertLess(abs(data['pressure'] - 969.1056565652227), 1e-4)
-        self.assertLess(abs(data['humidity'] - 41.07329061361983), 1e-4)
+        self.assertLess(abs(data["temperature"] - 24.65), 1e-4)
+        self.assertLess(abs(data["pressure"] - 969.1056565652227), 1e-4)
+        self.assertLess(abs(data["humidity"] - 41.07329061361983), 1e-4)
 
     @mock.patch("bme280pi.Sensor._initialize_bus", initialize_fake_bus)
-    def test_get_temperature(self):
+    def test_get_temperature(self) -> None:
         sensor = Sensor()
         temperature = sensor.get_temperature()
         self.assertLess(abs(temperature - 24.65), 1e-4)
 
     @mock.patch("bme280pi.Sensor._initialize_bus", initialize_fake_bus)
-    def test_get_pressure(self):
+    def test_get_pressure(self) -> None:
         sensor = Sensor()
         pressure = sensor.get_pressure()
         self.assertLess(abs(pressure - 969.1056565652227), 1e-4)
 
     @mock.patch("bme280pi.Sensor._initialize_bus", initialize_fake_bus)
-    def test_get_pressure_above_sea_level(self):
+    def test_get_pressure_above_sea_level(self) -> None:
         sensor = Sensor()
-        pressure = sensor.get_pressure(height_above_sea_level=440,
-                                       as_pressure_at_sea_level=True)
+        pressure = sensor.get_pressure(
+            height_above_sea_level=440,  # type: ignore[arg-type]
+            as_pressure_at_sea_level=True,
+        )
         self.assertLess(abs(pressure - 1019.0420210), 1e-4)
 
     @mock.patch("bme280pi.Sensor._initialize_bus", initialize_fake_bus)
-    def test_get_pressure_without_height_above_sea_level(self):
+    def test_get_pressure_without_height_above_sea_level(self) -> None:
         sensor = Sensor()
         with self.assertRaises(ValueError):
-            sensor.get_pressure(height_above_sea_level=None,
-                                as_pressure_at_sea_level=True)
+            sensor.get_pressure(
+                height_above_sea_level=None, as_pressure_at_sea_level=True
+            )
 
     @mock.patch("bme280pi.Sensor._initialize_bus", initialize_fake_bus)
-    def test_get_humidity(self):
+    def test_get_humidity(self) -> None:
         sensor = Sensor()
         humidity = sensor.get_humidity()
         self.assertLess(abs(humidity - 41.07329061361983), 1e-4)
@@ -140,33 +177,37 @@ class TestSensor(TestCase):
         humidity = sensor.get_humidity(relative=False)
         self.assertLess(abs(humidity - 0.009291279797753835), 1e-4)
 
-    def test_unconfigured_i2c(self):
-        with mock.patch('smbus.SMBus', FileNotFoundSMBus):
+    def test_unconfigured_i2c(self) -> None:
+        with mock.patch("smbus2.SMBus", FileNotFoundSMBus):
             with self.assertRaises(I2CException):
                 Sensor()
 
 
 class TestPrintSensor(TestCase):
     @mock.patch("bme280pi.Sensor._initialize_bus", initialize_fake_bus)
-    def test(self):
+    def test(self) -> None:
         sensor = Sensor()
         self.assertEqual(sensor.chip_id, "fake_chip_id")
         self.assertEqual(sensor.chip_version, "fake_version")
 
-        ref_message = "Temperature:  24.65 C\n" + \
-                      "Humidity:     41.07 %\n" + \
-                      "Pressure:     969.1 hPa\n"
+        ref_message = (
+            "Temperature:  24.65 C\n"
+            + "Humidity:     41.07 %\n"
+            + "Pressure:     969.1 hPa\n"
+        )
 
         with mock.patch("sys.stdout", new_callable=io.StringIO) as fake_out:
             sensor.print_data()
             self.assertEqual(fake_out.getvalue(), ref_message)
 
     @mock.patch("bme280pi.Sensor._initialize_bus", initialize_fake_bus)
-    def test_print_with_absolute_humidity(self):
+    def test_print_with_absolute_humidity(self) -> None:
         sensor = Sensor()
-        ref_message = "Temperature:  24.65 C\n" + \
-                      "Humidity:     0.009291 kg / m^3\n" + \
-                      "Pressure:     969.1 hPa\n"
+        ref_message = (
+            "Temperature:  24.65 C\n"
+            + "Humidity:     0.009291 kg / m^3\n"
+            + "Pressure:     969.1 hPa\n"
+        )
 
         with mock.patch("sys.stdout", new_callable=io.StringIO) as fake_out:
             sensor.print_data(relative_humidity=False)


### PR DESCRIPTION
This PR delivers a comprehensive modernization of the bme280pi package, with improvements spanning correctness, maintainability, documentation, and developer experience. 

###  Highlights 

- Migrate from deprecated `smbus` -> `smbus2`
    - Updated installation instructions (`python-smbus2`)  
    - Updated runtime dependency (`smbus2`)  
     - Added graceful fallback with clear errors when running off-device
- Full type annotations across all core modules (`physics.py`, `readout.py`, `sensor.py`, etc.)   
     - Enables static analysis (e.g. `mypy`) and better IDE support  
     - Test files updated accordingly with `# type: ignore `only where necessary
- New documentation infrastructure   
     - Full Read the Docs support via .`readthedocs.yaml`
     - Sphinx docs scaffolded (`docs/source/`, `Makefile`, `requirements.txt`)  
     - Auto-generated API reference with math support (e.g. Magnus formula)  
     - Hosted at: [https://readthedocs.org/projects/bme280pi/ ](https://readthedocs.org/projects/bme280pi/)
- Improved usability & troubleshooting   
     - Added Quickstart block in `README.md`
     - New “Troubleshooting” section (I2C enable, detection, permissions, forced mode)  
     - Updated badges (coverage, maintainability → [qlty.sh ](https://qlty.sh/))  
     - MIT license badge added
- Robust test suite enhancements
     - `test_readout.py` and `test_sensor.py` fully typed  
     - All test methods now typed with `-> None`, clearer structure

- Code hygiene   
     - `black` & `isort` config in `pyproject.toml`
     - Add pre-commit hooks and linting in code quality github action workflow
     - Minor formatting improvements (multi-line dicts, explicit float literals, etc.)  
     - Docstrings enhanced with math (LaTeX via Sphinx/MathJax) in `physics.py`
     - Updated CodeQL workflow (following [Github's recommendations](https://github.com/MarcoAndreaBuchmann/bme280pi/actions/runs/19714182419))

###  Breaking Changes (minimal) 

- Users must now install python3-smbus2 instead of python3-smbus.
    This is clearly documented in README.md, and aligns with current Raspberry Pi best practice (smbus2 is actively maintained; smbus is deprecated).  
- Python ≥3.8 still supported, but CI/docs use Python 3.13 on Ubuntu 24.04.