### PR TITLE
Add sphinx config (ReadTheDocs fix)

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,6 +4,10 @@
 # Required
 version: 2
 
+sphinx:
+  # Path to your Sphinx configuration file.
+  configuration: docs/source/conf.py
+
 # Set the OS, Python version, and other tools you might need
 build:
   os: ubuntu-24.04


### PR DESCRIPTION
Following instructions [1], this PR adds the sphinx config to enable documentation on readthedocs.com 

[1]
https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/
