### PR TITLE
ReadTheDocs fix: remove nbsphinx

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,3 +14,6 @@ build:
   tools:
     python: "3.13"
 
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,9 @@
-Sphinx>=7.2,<8
-sphinx-rtd-theme>=2.0,<3
-sphinx-autodoc-typehints>=1.25,<2
-sphinx-copybutton>=0.5,<1
+IPython
+Sphinx
+sphinx_rtd_theme
+sphinx_autodoc_typehints
+sphinx_copybutton
+sphinxcontrib-jquery
+sphinx-rtd-theme
+sphinx-autodoc-typehints
+sphinx-copybutton

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -35,7 +35,6 @@ version = release
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    "nbsphinx",
     "IPython.sphinxext.ipython_console_highlighting",
     "sphinx.ext.autodoc",
     "sphinx.ext.autodoc.typehints",


### PR DESCRIPTION
This PR introduces a number of fixes to get the ReadTheDocs documentation to build:
- remove `nbsphinx` extension (which isn't needed)
- ensure that doc requirements are installed before building docs
- remove fixed versions for doc requirements and add missing entries